### PR TITLE
fix(mobile): モバイルビューのレイアウト崩れ・メニューUI不具合を修正

### DIFF
--- a/company.html
+++ b/company.html
@@ -31,7 +31,7 @@
   <header class="header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SunyuTEC" style="width: 280px; height: auto;">
+        <img src="images/logo.png" alt="SunyuTEC" class="logo-img">
       </a>
       <nav>
         <button class="menu-toggle" aria-label="メニュー">

--- a/contact.html
+++ b/contact.html
@@ -31,7 +31,7 @@
   <header class="header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SunyuTEC" style="width: 280px; height: auto;">
+        <img src="images/logo.png" alt="SunyuTEC" class="logo-img">
       </a>
       <nav>
         <button class="menu-toggle" aria-label="メニュー">

--- a/css/style.css
+++ b/css/style.css
@@ -164,6 +164,18 @@ ul, ol {
   transition: var(--transition);
 }
 
+.menu-toggle.active span:nth-child(1) {
+  transform: rotate(45deg) translate(5px, 6px);
+}
+
+.menu-toggle.active span:nth-child(2) {
+  opacity: 0;
+}
+
+.menu-toggle.active span:nth-child(3) {
+  transform: rotate(-45deg) translate(5px, -6px);
+}
+
 /* ========================================
    Hero Section
    ======================================== */
@@ -913,7 +925,7 @@ ul, ol {
   padding: 140px 0 60px;
   text-align: center;
   color: var(--white);
-  margin-top: 60px;
+  margin-top: 70px;
 }
 
 .page-header h1 {

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   <header class="header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SunyuTEC" style="width: 280px; height: auto;">
+        <img src="images/logo.png" alt="SunyuTEC" class="logo-img">
       </a>
       <nav>
         <button class="menu-toggle" aria-label="メニュー">

--- a/js/main.js
+++ b/js/main.js
@@ -40,6 +40,9 @@ function initMobileMenu() {
       // アクセシビリティ対応
       const isExpanded = navMenu.classList.contains('active');
       menuToggle.setAttribute('aria-expanded', isExpanded);
+
+      // メニュー展開時のスクロール制御
+      document.body.style.overflow = isExpanded ? 'hidden' : '';
     });
 
     // メニューリンクをクリックしたらメニューを閉じる
@@ -48,6 +51,7 @@ function initMobileMenu() {
       link.addEventListener('click', function() {
         navMenu.classList.remove('active');
         menuToggle.classList.remove('active');
+        document.body.style.overflow = '';
       });
     });
 
@@ -56,6 +60,7 @@ function initMobileMenu() {
       if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
         navMenu.classList.remove('active');
         menuToggle.classList.remove('active');
+        document.body.style.overflow = '';
       }
     });
   }

--- a/service.html
+++ b/service.html
@@ -31,7 +31,7 @@
   <header class="header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SunyuTEC" style="width: 280px; height: auto;">
+        <img src="images/logo.png" alt="SunyuTEC" class="logo-img">
       </a>
       <nav>
         <button class="menu-toggle" aria-label="メニュー">

--- a/works.html
+++ b/works.html
@@ -31,7 +31,7 @@
   <header class="header">
     <div class="header-inner">
       <a href="index.html" class="logo">
-        <img src="images/logo.png" alt="SunyuTEC" style="width: 280px; height: auto;">
+        <img src="images/logo.png" alt="SunyuTEC" class="logo-img">
       </a>
       <nav>
         <button class="menu-toggle" aria-label="メニュー">


### PR DESCRIPTION
## 概要
issue#1のモバイルビューのレイアウト崩れ・メニューUI不具合を修正しました。

## 変更内容

- **FR-1**: 全5ページ（index/company/service/works/contact）のロゴからインラインスタイル（`width: 280px`）を削除し、CSSの`.logo-img`クラスのみでサイズ制御するように統一
- **FR-2**: ハンバーガーメニュー展開時に3本線→×マークに変形するCSS transitionを追加
- **FR-3**: メニュー展開中に`document.body.style.overflow = 'hidden'`で背景スクロールを防止（メニュー閉じ時に解除）
- **FR-4**: `.page-header`の`margin-top`を60px→70pxに変更し、`.hero`の`margin-top: 70px`と統一

## テスト方法

- Chrome DevToolsでモバイル表示（375px / 480px / 768px）に切り替え、全5ページでロゴがはみ出さないことを確認
- ハンバーガーメニューをクリックし、3本線→×マーク→3本線の変形を確認
- メニュー展開中に背景がスクロールしないことを確認
- 各ページのヘッダー直下コンテンツのmargin-topが統一されていることを確認

## チェックリスト

- [x] レスポンシブ表示確認（375px / 768px / 1024px / 1440px）
- [x] インラインスタイル不使用（コーディング規約準拠）
- [ ] 主要ブラウザ確認（Chrome / Safari / Firefox）
- [ ] iOS Safari・Chrome for Android での動作確認

Closes #1